### PR TITLE
fix proxy construction

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -10,7 +10,7 @@ local RedisClient = Emitter:extend()
 do
   local commands = require('./commands')
   for index = 1, #commands do
-    value = commands[index]:lower()
+    local value = commands[index]:lower()
     RedisClient[value] = function(self, ...)
       self.redisNativeClient:command(value, ...)
     end


### PR DESCRIPTION
This patch makes `value` in the proxy-construction-code local because otherwise it gets updated each for-iteration and causes all the proxies to call the same command (`ZUNIONSTORE`).
