### PR TITLE
update hiredis to point to new location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/hiredis"]
 	path = deps/hiredis
-	url = https://github.com/antirez/hiredis.git
+	url = git://github.com/redis/hiredis.git


### PR DESCRIPTION
The new location of hiredis is https://github.com/redis/hiredis.
Please note that this patch also uses the currently most up-to-date commit, which works for me.. :)
